### PR TITLE
Janitor now uses real user IDs instead of effective user IDs

### DIFF
--- a/lxc/execute
+++ b/lxc/execute
@@ -40,9 +40,9 @@ timeout -s KILL 20 \
 # process janitor
 lxc-attach --clear-env -n piston -- \
     /bin/bash -c "
-        while pgrep -u runner$runner > /dev/null
+        while pgrep -U runner$runner > /dev/null
         do
-            pkill -u runner$runner --signal SIGKILL
+            pkill -U runner$runner --signal SIGKILL
         done
 
         find /tmp -user runner$runner -delete


### PR DESCRIPTION
If runner spawns processes with a different effective UID (e.g. passwd), janitor needs to kill those too